### PR TITLE
refactor: using tacky builder plus some techdebt

### DIFF
--- a/src/c_ast/ast.rs
+++ b/src/c_ast/ast.rs
@@ -1,3 +1,8 @@
+//! C abstract syntax tree.
+//!
+//! This module defines the AST produced by the parser, representing the structure
+//! of a C program before any lowering or code generation.
+
 use crate::lexer::Token;
 
 #[derive(Clone, Debug)]

--- a/src/c_ast/ast.rs
+++ b/src/c_ast/ast.rs
@@ -110,6 +110,11 @@ impl Program {
     pub fn function_definition(&self) -> &FunctionDefinition {
         &self.0
     }
+
+    /// Consumes the program and returns the function definition.
+    pub fn into_function_definition(self) -> FunctionDefinition {
+        self.0
+    }
 }
 
 impl Block {
@@ -126,6 +131,11 @@ impl Block {
     pub fn block_items(&self) -> &Vec<BlockItem> {
         &self.0
     }
+
+    /// Consumes the block and returns the block items.
+    pub fn into_block_items(self) -> Vec<BlockItem> {
+        self.0
+    }
 }
 
 impl FunctionDefinition {
@@ -140,6 +150,11 @@ impl FunctionDefinition {
     pub fn body(&self) -> &Block {
         &self.1
     }
+
+    /// Consumes the function definition and returns (name, body).
+    pub fn into_parts(self) -> (Identifier, Block) {
+        (self.0, self.1)
+    }
 }
 
 impl Identifier {
@@ -149,6 +164,11 @@ impl Identifier {
 
     pub fn value(&self) -> &str {
         &self.0
+    }
+
+    /// Consumes the identifier and returns the inner string.
+    pub fn into_value(self) -> String {
+        self.0
     }
 
     /// Returns true if the identifier is a dummy label
@@ -174,6 +194,11 @@ impl Declaration {
 
     pub fn initializer(&self) -> Option<&Expression> {
         self.1.as_ref()
+    }
+
+    /// Consumes the declaration and returns (name, initializer).
+    pub fn into_parts(self) -> (Identifier, Option<Expression>) {
+        (self.0, self.1)
     }
 
     pub fn is_declaration(token: Option<&&Token>) -> bool {

--- a/src/c_ast/parser.rs
+++ b/src/c_ast/parser.rs
@@ -97,7 +97,7 @@ impl Declaration {
         let name = Identifier::parse_id(tokens)?;
         let mut initializer = None;
         if let Some(Token::Assignment) = tokens.peek() {
-            let _ = tokens.next(); // consume '='
+            token_assert(Token::Assignment, tokens)?;
             initializer = Expression::parse_opt_exp(tokens, Token::Semicolon)?;
         }
         token_assert(Token::Semicolon, tokens)?;
@@ -136,7 +136,7 @@ impl Statement {
             Token::Semicolon => {
                 trace!("[parser] <statement> null");
 
-                let _ = tokens.next();
+                token_assert(Token::Semicolon, tokens)?;
                 Statement::Null
             }
             Token::Return => {
@@ -152,7 +152,7 @@ impl Statement {
             Token::If => {
                 trace!("[parser] <statement> if");
 
-                let _ = tokens.next(); // consume 'if'
+                token_assert(Token::If, tokens)?;
                 token_assert(Token::OpenParen, tokens)?;
                 let expr = Expression::parse_exp(tokens, Token::CloseParen)?;
                 token_assert(Token::CloseParen, tokens)?;
@@ -160,7 +160,7 @@ impl Statement {
                 let el = if let Some(Token::Else) = tokens.peek() {
                     debug!("[parser] found else branch");
 
-                    let _ = tokens.next(); // consume 'else'
+                    token_assert(Token::Else, tokens)?;
                     Some(Box::new(Statement::parse_st(tokens)?))
                 } else {
                     None
@@ -176,7 +176,7 @@ impl Statement {
             Token::Break => {
                 trace!("[parser] <statement> break");
 
-                let _ = tokens.next(); // consume 'break'
+                token_assert(Token::Break, tokens)?;
                 token_assert(Token::Semicolon, tokens)?;
                 Statement::Break(Identifier::new("dummy".to_string()))
             }
@@ -328,7 +328,7 @@ impl Expression {
         match next_token {
             Token::Constant(n) => {
                 let n = n.clone();
-                let _ = tokens.next();
+                token_assert(Token::Constant(n.clone()), tokens)?;
                 n.parse::<i32>().map(Expression::Constant).map_err(|_| {
                     error!("[parser] invalid constant: {n}");
 
@@ -342,7 +342,7 @@ impl Expression {
                 Ok(Expression::Unary(unary, Box::new(exp)))
             }
             Token::OpenParen => {
-                let _ = tokens.next();
+                token_assert(Token::OpenParen, tokens)?;
                 let exp = Expression::parse_exp(tokens, Token::CloseParen)?;
                 token_assert(Token::CloseParen, tokens)?;
 

--- a/src/c_ast/semantic/var_res.rs
+++ b/src/c_ast/semantic/var_res.rs
@@ -52,7 +52,7 @@ impl VariableResolver {
             .insert(var_name.value().to_string(), (unique_name, true));
     }
 
-    /// returns a copy of the variables map with all the variables marked as undeclared for the current block
+    /// Returns a copy of the variables map with all the variables marked as undeclared for the current block.
     fn copy_variable_map(&self) -> HashMap<VarName, VarValue> {
         self.0
             .clone() // copy variables map

--- a/src/codegen/x64/ast.rs
+++ b/src/codegen/x64/ast.rs
@@ -7,12 +7,12 @@ pub struct AsmProgram {
 
 #[derive(Clone)]
 pub struct AsmFunctionDefinition {
-    pub name: AsmIdetifier,
+    pub name: AsmIdentifier,
     pub instructions: Vec<AsmInstruction>,
 }
 
 #[derive(Clone, Hash, Eq, PartialEq, Debug)]
-pub struct AsmIdetifier {
+pub struct AsmIdentifier {
     pub value: String,
 }
 
@@ -25,10 +25,10 @@ pub enum AsmInstruction {
     Cmp(AsmOperand, AsmOperand),
     Idiv(AsmOperand),
     Cdq,
-    Jmp(AsmIdetifier),
-    JmpCC(AsmCondCode, AsmIdetifier),
+    Jmp(AsmIdentifier),
+    JmpCC(AsmCondCode, AsmIdentifier),
     SetCC(AsmCondCode, AsmOperand),
-    Label(AsmIdetifier),
+    Label(AsmIdentifier),
     AllocateStack(i32),
     Ret,
 }
@@ -57,7 +57,7 @@ pub enum AsmBinaryOperator {
 pub enum AsmOperand {
     Imm(i32),
     Register(Reg),
-    Pseudo(AsmIdetifier),
+    Pseudo(AsmIdentifier),
     Stack(i32),
 }
 
@@ -90,7 +90,7 @@ impl AsmProgram {
 }
 
 impl AsmFunctionDefinition {
-    pub fn new(name: AsmIdetifier, instructions: Vec<AsmInstruction>) -> Self {
+    pub fn new(name: AsmIdentifier, instructions: Vec<AsmInstruction>) -> Self {
         AsmFunctionDefinition { name, instructions }
     }
 }

--- a/src/codegen/x64/ast.rs
+++ b/src/codegen/x64/ast.rs
@@ -1,4 +1,7 @@
-//! This module defines the structure of the x64 assembly code as an AST
+//! x86_64 assembly AST.
+//!
+//! This module defines the AST representing x86_64 assembly instructions,
+//! used as the final IR before emitting textual assembly.
 
 #[derive(Clone)]
 pub struct AsmProgram {

--- a/src/codegen/x64/fixer/instruction_fix.rs
+++ b/src/codegen/x64/fixer/instruction_fix.rs
@@ -5,7 +5,43 @@ use crate::{
     common::folder::FolderAsm,
 };
 
-/// This pass fixes some instructions that are not supported by the x64 architecture.
+/// This pass fixes instructions that violate x86_64 encoding constraints.
+///
+/// # x86_64 Constraints Handled
+///
+/// The x86_64 architecture has specific encoding rules that our initial code generation
+/// may violate. This pass rewrites those patterns into valid instruction sequences.
+///
+/// ## Memory-to-memory operations
+/// Most x86_64 instructions cannot have both operands in memory. We use R10 as a
+/// scratch register to split these into two instructions:
+/// - `mov mem, mem` → `mov mem, R10` + `mov R10, mem`
+/// - `add/sub mem, mem` → `mov mem, R10` + `add/sub R10, mem`
+/// - `and/or/xor mem, mem` → `mov mem, R10` + `and/or/xor R10, mem`
+/// - `cmp mem, mem` → `mov mem, R10` + `cmp R10, mem`
+///
+/// ## Division (`idiv`)
+/// The `idiv` instruction cannot take an immediate operand:
+/// - `idiv imm` → `mov imm, R10` + `idiv R10`
+///
+/// ## Multiplication (`imul`)
+/// The two-operand `imul` instruction requires the destination to be a register.
+/// We use R11 as scratch because the source might already be in R10:
+/// - `imul src, mem` → `mov mem, R11` + `imul src, R11` + `mov R11, mem`
+///
+/// ## Shifts (`shl`/`shr`)
+/// Shift instructions require the count to be in the CL register (low byte of CX):
+/// - `shl R10, mem` → `mov R10, CX` + `shl CL, mem`
+/// - `shl mem, mem` → `mov mem, CX` + `shl CL, mem`
+///
+/// ## Compare with immediate as second operand
+/// The `cmp` instruction cannot have an immediate as the second operand:
+/// - `cmp op, imm` → `mov imm, R11` + `cmp op, R11`
+///
+/// # Scratch Register Policy
+/// - **R10**: Primary scratch register for most rewrites
+/// - **R11**: Used when R10 might conflict (e.g., `imul`, `cmp` with immediate)
+/// - **CX/CL**: Used exclusively for shift counts
 #[derive(Default)]
 pub struct InstructionFixer {
     last_offset: Option<i32>, // space reserved for stack
@@ -60,60 +96,67 @@ impl FolderAsm for InstructionFixer {
         use AsmOperand::*;
 
         let result = match instruction {
+            // x86_64: mov cannot have both operands in memory
             Mov(Stack(src), Stack(dst)) => {
                 vec![
-                    Comment("splited mov into two mov instructions".to_string()),
+                    Comment("fix: mov mem,mem -> mov mem,R10 + mov R10,mem".to_string()),
                     Mov(Stack(src), Register(Reg::R10)),
                     Mov(Register(Reg::R10), Stack(dst)),
                 ]
             }
+            // x86_64: idiv cannot take an immediate operand
             Idiv(Imm(num)) => vec![
-                Comment("splited idiv into mov idiv".to_string()),
+                Comment("fix: idiv imm -> mov imm,R10 + idiv R10".to_string()),
                 Mov(Imm(num), Register(Reg::R10)),
                 Idiv(Register(Reg::R10)),
             ],
+            // x86_64: add/sub cannot have both operands in memory
             Binary(bin_op @ (Add | Sub), Stack(src), Stack(dst)) => vec![
-                Comment("splitted add/sub into mov add/sub instructions".to_string()),
+                Comment("fix: add/sub mem,mem -> mov mem,R10 + op R10,mem".to_string()),
                 Mov(Stack(src), Register(Reg::R10)),
                 Binary(bin_op, Register(Reg::R10), Stack(dst)),
             ],
+            // x86_64: imul destination must be a register
             Binary(Mult, src, Stack(dst)) => {
                 vec![
-                    Comment("splitted mul into mov mul mov instructions".to_string()),
+                    Comment("fix: imul src,mem -> mov mem,R11 + imul src,R11 + mov R11,mem".to_string()),
                     Mov(Stack(dst), Register(Reg::R11)),
                     Binary(Mult, src, Register(Reg::R11)),
                     Mov(Register(Reg::R11), Stack(dst)),
                 ]
             }
+            // x86_64: bitwise ops cannot have both operands in memory
             Binary(bin_op @ (BitwiseAnd | BitwiseOr | BitwiseXor), Stack(src), Stack(dst)) => {
                 vec![
-                    Comment(
-                        "splitted bitwise and/or/xor into mov and/or/xor instructions".to_string(),
-                    ),
+                    Comment("fix: and/or/xor mem,mem -> mov mem,R10 + op R10,mem".to_string()),
                     Mov(Stack(src), Register(Reg::R10)),
                     Binary(bin_op, Register(Reg::R10), Stack(dst)),
                 ]
             }
+            // x86_64: shift count must be in CL register
             Binary(bin_op @ (LeftShift | RightShift), Register(Reg::R10), Stack(dst)) => vec![
-                Comment("splitted shl/shr into mov and instructions".to_string()),
+                Comment("fix: shl/shr R10,mem -> mov R10,CX + op CL,mem".to_string()),
                 Mov(Register(Reg::R10), Register(Reg::CX)),
                 Binary(bin_op, Register(Reg::CL), Stack(dst)),
             ],
+            // x86_64: shift count must be in CL register
             Binary(bin_op @ (LeftShift | RightShift), Stack(src), Stack(dst)) => {
                 vec![
-                    Comment("splitted shl/shr into mov and instructions".to_string()),
+                    Comment("fix: shl/shr mem,mem -> mov mem,CX + op CL,mem".to_string()),
                     Mov(Stack(src), Register(Reg::CX)),
                     Binary(bin_op, Register(Reg::CL), Stack(dst)),
                 ]
             }
+            // x86_64: cmp cannot have both operands in memory
             Cmp(Stack(op_1), Stack(op_2)) => vec![
-                Comment("splitted cmp into mov and cmpl instructions".to_string()),
+                Comment("fix: cmp mem,mem -> mov mem,R10 + cmp R10,mem".to_string()),
                 Mov(Stack(op_1), Register(Reg::R10)),
                 Cmp(Register(Reg::R10), Stack(op_2)),
             ],
+            // x86_64: cmp second operand cannot be an immediate
             Cmp(op_1, Imm(constant)) => {
                 vec![
-                    Comment("splitted cmp into mov and cmpl instructions".to_string()),
+                    Comment("fix: cmp op,imm -> mov imm,R11 + cmp op,R11".to_string()),
                     Mov(Imm(constant), Register(Reg::R11)),
                     Cmp(op_1, Register(Reg::R11)),
                 ]

--- a/src/codegen/x64/fixer/instruction_fix.rs
+++ b/src/codegen/x64/fixer/instruction_fix.rs
@@ -96,7 +96,7 @@ impl FolderAsm for InstructionFixer {
         use AsmOperand::*;
 
         let result = match instruction {
-            // Generic mem-mem patterns (use helpers)
+            // generic mem-mem patterns (use helpers)
             Mov(Stack(src), Stack(dst)) => fix_mov_mem_mem(src, dst),
             Binary(bin_op @ (Add | Sub), Stack(src), Stack(dst)) => {
                 fix_binary_mem_mem(bin_op, src, dst)
@@ -106,14 +106,14 @@ impl FolderAsm for InstructionFixer {
             }
             Cmp(Stack(op_1), Stack(op_2)) => fix_cmp_mem_mem(op_1, op_2),
 
-            // Special case: idiv cannot take an immediate operand
+            // special case: idiv cannot take an immediate operand
             Idiv(Imm(num)) => vec![
                 Comment("fix: idiv imm -> mov imm,R10 + idiv R10".to_string()),
                 Mov(Imm(num), Register(Reg::R10)),
                 Idiv(Register(Reg::R10)),
             ],
 
-            // Special case: imul destination must be a register (uses R11)
+            // special case: imul destination must be a register (uses R11)
             Binary(Mult, src, Stack(dst)) => {
                 vec![
                     Comment(
@@ -125,7 +125,7 @@ impl FolderAsm for InstructionFixer {
                 ]
             }
 
-            // Special case: shift count must be in CL register
+            // special case: shift count must be in CL register
             Binary(bin_op @ (LeftShift | RightShift), Register(Reg::R10), Stack(dst)) => vec![
                 Comment("fix: shl/shr R10,mem -> mov R10,CX + op CL,mem".to_string()),
                 Mov(Register(Reg::R10), Register(Reg::CX)),
@@ -139,7 +139,7 @@ impl FolderAsm for InstructionFixer {
                 ]
             }
 
-            // Special case: cmp second operand cannot be an immediate (uses R11)
+            // special case: cmp second operand cannot be an immediate (uses R11)
             Cmp(op_1, Imm(constant)) => {
                 vec![
                     Comment("fix: cmp op,imm -> mov imm,R11 + cmp op,R11".to_string()),

--- a/src/codegen/x64/fixer/mod.rs
+++ b/src/codegen/x64/fixer/mod.rs
@@ -1,2 +1,3 @@
+/// Fix-up helpers for common x86_64 constraint violations
 pub mod instruction_fix;
 pub mod reg_replace;

--- a/src/codegen/x64/from.rs
+++ b/src/codegen/x64/from.rs
@@ -9,6 +9,52 @@ use crate::{
     },
 };
 
+// helpers for common asm emission patterns
+
+fn emit_conditional_jump(
+    condition: TackyValue,
+    target: TackyIdentifier,
+    jump_when_zero: bool,
+) -> Vec<AsmInstruction> {
+    let cond_code = if jump_when_zero {
+        AsmCondCode::E
+    } else {
+        AsmCondCode::NE
+    };
+    vec![
+        AsmInstruction::Cmp(AsmOperand::Imm(0), AsmOperand::from(condition)),
+        AsmInstruction::JmpCC(cond_code, AsmIdentifier::from(target)),
+    ]
+}
+
+fn emit_relational(
+    op: TackyBinaryOperator,
+    src_1: TackyValue,
+    src_2: TackyValue,
+    dst: TackyValue,
+) -> Vec<AsmInstruction> {
+    vec![
+        AsmInstruction::Cmp(AsmOperand::from(src_2), AsmOperand::from(src_1)),
+        AsmInstruction::Mov(AsmOperand::Imm(0), AsmOperand::from(dst.clone())),
+        AsmInstruction::SetCC(AsmCondCode::from(op), AsmOperand::from(dst)),
+    ]
+}
+
+fn emit_div_rem(
+    is_div: bool,
+    src_1: TackyValue,
+    src_2: TackyValue,
+    dst: TackyValue,
+) -> Vec<AsmInstruction> {
+    let result_reg = if is_div { Reg::AX } else { Reg::DX };
+    vec![
+        AsmInstruction::Mov(AsmOperand::from(src_1), AsmOperand::Register(Reg::AX)),
+        AsmInstruction::Cdq,
+        AsmInstruction::Idiv(AsmOperand::from(src_2)),
+        AsmInstruction::Mov(AsmOperand::Register(result_reg), AsmOperand::from(dst)),
+    ]
+}
+
 impl From<TackyProgram> for AsmProgram {
     fn from(tacky_program: TackyProgram) -> Self {
         AsmProgram {
@@ -47,65 +93,39 @@ impl AsmInstruction {
                 AsmInstruction::Mov(AsmOperand::from(src), AsmOperand::from(dst.clone())),
                 AsmInstruction::Unary(AsmUnaryOperator::from(unary_op), AsmOperand::from(dst)),
             ],
-            TackyInstruction::Binary(op, src_1, src_2, dst) => {
-                let is_div = op == TackyBinaryOperator::Divide;
-                match &op {
-                    // “addition, subtraction, and multiplication,
-                    // we convert a single TACKY instruction into two assembly instructions”
-                    TackyBinaryOperator::Add
-                    | TackyBinaryOperator::Subtract
-                    | TackyBinaryOperator::Multiply
-                    // bitwise operators
-                    | TackyBinaryOperator::BitwiseAnd
-                    | TackyBinaryOperator::BitwiseOr
-                    | TackyBinaryOperator::BitwiseXor
-                    | TackyBinaryOperator::LeftShift
-                    | TackyBinaryOperator::RightShift => vec![
-                        AsmInstruction::Comment(format!("add/sub/mul/bitwise operator: {:?}", op.clone())),
-                        AsmInstruction::Mov(AsmOperand::from(src_1), AsmOperand::from(dst.clone())),
-                        AsmInstruction::Binary(
-                            AsmBinaryOperator::from(op),
-                            AsmOperand::from(src_2),
-                            AsmOperand::from(dst),
-                        ),
-                    ],
-                    // relational operators
-                    TackyBinaryOperator::Equal
-                    | TackyBinaryOperator::NotEqual
-                    | TackyBinaryOperator::GreaterThan
-                    | TackyBinaryOperator::LessThan
-                    | TackyBinaryOperator::LessThanOrEqual
-                    | TackyBinaryOperator::GreaterThanOrEqual => vec![
-                        AsmInstruction::Comment(format!("relational operator: {:?}", op.clone())),
-                        AsmInstruction::Cmp(AsmOperand::from(src_2), AsmOperand::from(src_1)),
-                        AsmInstruction::Mov(AsmOperand::Imm(0), AsmOperand::from(dst.clone())),
-                        AsmInstruction::SetCC(AsmCondCode::from(op), AsmOperand::from(dst)),
-                    ],
-                    TackyBinaryOperator::Divide | TackyBinaryOperator::Remainder => {
-                        let reg = if is_div { AsmOperand::Register(Reg::AX) } else { AsmOperand::Register(Reg::DX) };
-                        vec![
-                            AsmInstruction::Comment(format!("div/rem operator: {:?}", op.clone())),
-                            AsmInstruction::Mov(
-                                AsmOperand::from(src_1),
-                                AsmOperand::Register(Reg::AX),
-                            ),
-                            AsmInstruction::Cdq,
-                            AsmInstruction::Idiv(AsmOperand::from(src_2)),
-                            AsmInstruction::Mov(reg, AsmOperand::from(dst)),
-                        ]
-                    }
-                }
-            }
+            TackyInstruction::Binary(op, src_1, src_2, dst) => match op {
+                // arithmetic and bitwise
+                TackyBinaryOperator::Add
+                | TackyBinaryOperator::Subtract
+                | TackyBinaryOperator::Multiply
+                | TackyBinaryOperator::BitwiseAnd
+                | TackyBinaryOperator::BitwiseOr
+                | TackyBinaryOperator::BitwiseXor
+                | TackyBinaryOperator::LeftShift
+                | TackyBinaryOperator::RightShift => vec![
+                    AsmInstruction::Mov(AsmOperand::from(src_1), AsmOperand::from(dst.clone())),
+                    AsmInstruction::Binary(
+                        AsmBinaryOperator::from(op),
+                        AsmOperand::from(src_2),
+                        AsmOperand::from(dst),
+                    ),
+                ],
+                // relational
+                TackyBinaryOperator::Equal
+                | TackyBinaryOperator::NotEqual
+                | TackyBinaryOperator::GreaterThan
+                | TackyBinaryOperator::LessThan
+                | TackyBinaryOperator::LessThanOrEqual
+                | TackyBinaryOperator::GreaterThanOrEqual => emit_relational(op, src_1, src_2, dst),
+                // division and remainder
+                TackyBinaryOperator::Divide => emit_div_rem(true, src_1, src_2, dst),
+                TackyBinaryOperator::Remainder => emit_div_rem(false, src_1, src_2, dst),
+            },
             TackyInstruction::Jump(id) => vec![AsmInstruction::Jmp(AsmIdentifier::from(id))],
-            // TODO: this is almost same as JumpIfNotZero
-            TackyInstruction::JumpIfZero(condition, target) => vec![
-                AsmInstruction::Cmp(AsmOperand::Imm(0), AsmOperand::from(condition)),
-                AsmInstruction::JmpCC(AsmCondCode::E, AsmIdentifier::from(target)),
-            ],
-            TackyInstruction::JumpIfNotZero(condition, target) => vec![
-                AsmInstruction::Cmp(AsmOperand::Imm(0), AsmOperand::from(condition)),
-                AsmInstruction::JmpCC(AsmCondCode::NE, AsmIdentifier::from(target)),
-            ],
+            TackyInstruction::JumpIfZero(cond, target) => emit_conditional_jump(cond, target, true),
+            TackyInstruction::JumpIfNotZero(cond, target) => {
+                emit_conditional_jump(cond, target, false)
+            }
             TackyInstruction::Copy(src, dst) => vec![AsmInstruction::Mov(
                 AsmOperand::from(src),
                 AsmOperand::from(dst),
@@ -137,7 +157,6 @@ impl From<TackyUnaryOperator> for AsmUnaryOperator {
         match tacky_unary_operator {
             TackyUnaryOperator::Negate => AsmUnaryOperator::Neg,
             TackyUnaryOperator::Complement => AsmUnaryOperator::Not,
-            // logical unary operators
             TackyUnaryOperator::Not => AsmUnaryOperator::Not,
         }
     }

--- a/src/codegen/x64/from.rs
+++ b/src/codegen/x64/from.rs
@@ -23,9 +23,8 @@ impl From<TackyFunctionDefinition> for AsmFunctionDefinition {
             name: AsmIdentifier::from(tacky_function_definition.name),
             instructions: tacky_function_definition
                 .instructions
-                .iter()
-                // TODO: remove clone
-                .flat_map(|i| AsmInstruction::from(i.clone()))
+                .into_iter()
+                .flat_map(AsmInstruction::from)
                 .collect::<Vec<AsmInstruction>>(),
         }
     }

--- a/src/codegen/x64/from.rs
+++ b/src/codegen/x64/from.rs
@@ -1,6 +1,6 @@
 use crate::{
     codegen::x64::ast::{
-        AsmBinaryOperator, AsmCondCode, AsmFunctionDefinition, AsmIdetifier, AsmInstruction,
+        AsmBinaryOperator, AsmCondCode, AsmFunctionDefinition, AsmIdentifier, AsmInstruction,
         AsmOperand, AsmProgram, AsmUnaryOperator, Reg,
     },
     tacky::ast::{
@@ -20,7 +20,7 @@ impl From<TackyProgram> for AsmProgram {
 impl From<TackyFunctionDefinition> for AsmFunctionDefinition {
     fn from(tacky_function_definition: TackyFunctionDefinition) -> Self {
         AsmFunctionDefinition {
-            name: AsmIdetifier::from(tacky_function_definition.name),
+            name: AsmIdentifier::from(tacky_function_definition.name),
             instructions: tacky_function_definition
                 .instructions
                 .iter()
@@ -97,21 +97,21 @@ impl AsmInstruction {
                     }
                 }
             }
-            TackyInstruction::Jump(id) => vec![AsmInstruction::Jmp(AsmIdetifier::from(id))],
+            TackyInstruction::Jump(id) => vec![AsmInstruction::Jmp(AsmIdentifier::from(id))],
             // TODO: this is almost same as JumpIfNotZero
             TackyInstruction::JumpIfZero(condition, target) => vec![
                 AsmInstruction::Cmp(AsmOperand::Imm(0), AsmOperand::from(condition)),
-                AsmInstruction::JmpCC(AsmCondCode::E, AsmIdetifier::from(target)),
+                AsmInstruction::JmpCC(AsmCondCode::E, AsmIdentifier::from(target)),
             ],
             TackyInstruction::JumpIfNotZero(condition, target) => vec![
                 AsmInstruction::Cmp(AsmOperand::Imm(0), AsmOperand::from(condition)),
-                AsmInstruction::JmpCC(AsmCondCode::NE, AsmIdetifier::from(target)),
+                AsmInstruction::JmpCC(AsmCondCode::NE, AsmIdentifier::from(target)),
             ],
             TackyInstruction::Copy(src, dst) => vec![AsmInstruction::Mov(
                 AsmOperand::from(src),
                 AsmOperand::from(dst),
             )],
-            TackyInstruction::Label(id) => vec![AsmInstruction::Label(AsmIdetifier::from(id))],
+            TackyInstruction::Label(id) => vec![AsmInstruction::Label(AsmIdentifier::from(id))],
         }
     }
 }
@@ -120,14 +120,14 @@ impl From<TackyValue> for AsmOperand {
     fn from(tacky_value: TackyValue) -> Self {
         match tacky_value {
             TackyValue::Constant(c) => AsmOperand::Imm(c),
-            TackyValue::Var(id) => AsmOperand::Pseudo(AsmIdetifier::from(id)),
+            TackyValue::Var(id) => AsmOperand::Pseudo(AsmIdentifier::from(id)),
         }
     }
 }
 
-impl From<TackyIdentifier> for AsmIdetifier {
+impl From<TackyIdentifier> for AsmIdentifier {
     fn from(tacky_identifier: TackyIdentifier) -> Self {
-        AsmIdetifier {
+        AsmIdentifier {
             value: tacky_identifier.value,
         }
     }

--- a/src/common/folder.rs
+++ b/src/common/folder.rs
@@ -5,7 +5,7 @@ use crate::c_ast::ast::{
     Identifier, Program, Statement, UnaryOperator,
 };
 use crate::codegen::x64::ast::{
-    AsmBinaryOperator, AsmCondCode, AsmFunctionDefinition, AsmIdetifier, AsmInstruction,
+    AsmBinaryOperator, AsmCondCode, AsmFunctionDefinition, AsmIdentifier, AsmInstruction,
     AsmOperand, AsmProgram, AsmUnaryOperator, Reg,
 };
 use crate::tacky::ast::{
@@ -378,7 +378,7 @@ pub trait FolderAsm {
         }
     }
 
-    fn fold_id(&mut self, identifier: AsmIdetifier) -> Result<AsmIdetifier, String> {
+    fn fold_id(&mut self, identifier: AsmIdentifier) -> Result<AsmIdentifier, String> {
         Ok(identifier)
     }
 

--- a/src/common/folder.rs
+++ b/src/common/folder.rs
@@ -1,3 +1,29 @@
+//! AST folder traits for recursive tree transformations.
+//!
+//! This module provides the "folder" pattern for traversing and transforming ASTs.
+//! Each folder trait provides default implementations that recursively visit all nodes,
+//! allowing passes to override only the specific node types they care about.
+//!
+//! # Available Folders
+//!
+//! - **FolderC**: Transforms C AST → C AST (used by semantic passes)
+//! - **FolderTacky**: Transforms TACKY IR → TACKY IR
+//! - **FolderAsm**: Transforms ASM IR → ASM IR (used by codegen fix-up passes)
+//!
+//! # Usage
+//!
+//! ```ignore
+//! struct MyPass;
+//!
+//! impl FolderC for MyPass {
+//!     fn name(&self) -> &'static str { "my_pass" }
+//!
+//!     fn fold_expr(&mut self, expr: Expression) -> Result<Expression, String> {
+//!         // custom logic here
+//!     }
+//! }
+//! ```
+
 use log::{info, trace};
 
 use crate::c_ast::ast::{
@@ -18,7 +44,7 @@ use crate::tacky::ast::{
 /// another AST. This is useful when we want to traverse the AST and perform some operation on a
 /// specific node type.
 pub trait FolderC {
-    /// name of the pass for logging
+    /// Name of the pass for logging.
     fn name(&self) -> &'static str;
 
     fn fold_prog(&mut self, program: Program) -> Result<Program, String> {
@@ -201,7 +227,7 @@ pub trait FolderC {
 /// Another folder trait that can be used to fold Tacky AST into another Tacky AST.
 #[allow(unused)]
 pub trait FolderTacky {
-    /// name of the pass for logging
+    /// Name of the pass for logging.
     fn name(&self) -> &'static str;
 
     fn create() -> Self
@@ -301,7 +327,7 @@ pub trait FolderTacky {
 
 /// Another folder trait that can be used to fold Asm AST into another Asm AST.
 pub trait FolderAsm {
-    /// name of the pass for logging
+    /// Name of the pass for logging.
     fn name(&self) -> &'static str;
 
     fn create() -> Self

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,3 +1,19 @@
+//! Compiler driver.
+//!
+//! Orchestrates the full compilation pipeline from C source to executable.
+//!
+//! # Pipeline Stages
+//!
+//! 1. **Preprocessing**: Invokes `gcc -E` to expand macros and includes
+//! 2. **Lexing**: Tokenizes the preprocessed source
+//! 3. **Parsing**: Builds the C AST from tokens
+//! 4. **Semantic analysis**: Variable resolution and loop labeling
+//! 5. **TACKY generation**: Lowers C AST to three-address code IR
+//! 6. **Codegen**: Converts TACKY to x86_64 assembly AST
+//! 7. **Fix-up passes**: Replaces pseudo-registers and fixes instruction constraints
+//! 8. **Emission**: Writes assembly to `.asm` file
+//! 9. **Assemble & link**: Invokes `gcc` to produce the final executable
+
 use std::{fs, path::Path, process::Command};
 
 use clap::Parser;

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -230,7 +230,7 @@ pub fn binary_operators() -> Vec<Token> {
         Token::LessThan,
         Token::GreaterThanOrEqual,
         Token::LessThanOrEqual,
-        // Assignment
+        // assignment
         Token::Assignment,
         // conditional operators
         // this is not a binary oeprator but is useful for parsing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-// Library crate for the fcc compiler
+// library crate for the fcc compiler
 //
-// This file exposes the public API of the fcc compiler for use in tests
+// this file exposes the public API of the fcc compiler for use in tests
 // and other external crates. It makes all the main modules available
 // for unit testing and integration.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,73 @@
+//! fcc: A toy C compiler targeting x86_64.
+//!
+//! This project is a rust implemetation of the book "Writing a C Compiler" by Nora Sandler.
+//! It implements a subset of C, compiling to x86_64 assembly on macOS/Linux.
+//!
+//! # Compiler Pipeline
+//!
+//! ```text
+//!
+//!                               program.c
+//!                                   │
+//!                                   ▼
+//!                          ┌────────────────┐
+//!                          │     Lexer      │
+//!                          └────────┬───────┘
+//!                                   │
+//!                              Token list
+//!                                   │
+//!                                   ▼
+//!                          ┌────────────────┐
+//!                          │     Parser     │
+//!                          └────────┬───────┘
+//!                                   │
+//!                                 AST
+//!                                   │
+//!                                   ▼
+//!                       ┌──────────────────────┐
+//!                       │  Semantic analysis   │
+//!                       │ ┌──────────────────┐ │
+//!                       │ │  Variable        │ │
+//!                       │ │  Resolution      │ │
+//!                       │ ├──────────────────┤ │
+//!                       │ │  Loop labeling   │ │
+//!                       │ └──────────────────┘ │
+//!                       └───────────┬──────────┘
+//!                                   │
+//!                                   │
+//!                           Transformed AST
+//!                                   │
+//!                                   ▼
+//!                       ┌──────────────────────┐
+//!                       │   TACKY generation   │
+//!                       └───────────┬──────────┘
+//!                                   │
+//!                                TACKY
+//!                                   │
+//!                                   ▼
+//!                       ┌──────────────────────┐
+//!                       │ Assembly generation  │
+//!                       │ ┌──────────────────┐ │
+//!                       │ │ TACKY to assembly│ │
+//!                       │ ├──────────────────┤ │
+//!                       │ │  Replacing       │ │
+//!                       │ │  pseudoregisters │ │
+//!                       │ ├──────────────────┤ │
+//!                       │ │ Instruction fix  │ │
+//!                       │ └──────────────────┘ │
+//!                       └───────────┬──────────┘
+//!                                   │
+//!                               Assembly
+//!                                   │
+//!                                   ▼
+//!                       ┌──────────────────────┐
+//!                       │    Code emission     │
+//!                       └───────────┬──────────┘
+//!                                   │
+//!                                   ▼
+//!                               program.s
+//! ```
+
 #![allow(clippy::uninlined_format_args)]
 
 use crate::driver::CompilerDriver;

--- a/src/tacky/ast.rs
+++ b/src/tacky/ast.rs
@@ -1,9 +1,4 @@
-//! This module contains  tacky AST which is an intermediate
-//! representation of the source code.
-
-use std::sync::atomic::AtomicUsize;
-
-use crate::{c_ast::ast::Identifier, common::util::temporary_name};
+//! This module contains the TACKY AST, an intermediate representation of the source code.
 
 pub struct TackyProgram {
     pub function_definition: TackyFunctionDefinition,
@@ -70,25 +65,6 @@ pub enum TackyBinaryOperator {
     LessThanOrEqual,
 }
 
-static COUNTER: AtomicUsize = AtomicUsize::new(0);
-
-impl TackyIdentifier {
-    /// Creates a new identifier with the given value
-    /// note: it increments the counter
-    pub fn new(value: &str) -> TackyIdentifier {
-        TackyIdentifier {
-            value: temporary_name(value, &COUNTER),
-        }
-    }
-
-    /// Creates a new identifier with the given prefix and the label's value
-    /// note: it does not increment the counter
-    pub fn with_prefix(prefix: &str, label: Identifier) -> TackyIdentifier {
-        let id = prefix.to_string() + &label.value();
-        TackyIdentifier { value: id }
-        // Self::new(&id)
-    }
-}
 
 impl TackyProgram {
     pub fn new(function_definition: TackyFunctionDefinition) -> Self {
@@ -101,5 +77,15 @@ impl TackyProgram {
 impl TackyFunctionDefinition {
     pub fn new(name: TackyIdentifier, instructions: Vec<TackyInstruction>) -> Self {
         TackyFunctionDefinition { name, instructions }
+    }
+}
+
+impl TackyIdentifier {
+    /// Creates a new identifier with the given value.
+    /// Note: For unique names in lowering, use `TackyBuilder::fresh_temp` or `fresh_label` instead.
+    pub fn new(value: &str) -> Self {
+        TackyIdentifier {
+            value: value.to_string(),
+        }
     }
 }

--- a/src/tacky/ast.rs
+++ b/src/tacky/ast.rs
@@ -1,4 +1,7 @@
-//! This module contains the TACKY AST, an intermediate representation of the source code.
+//! TACKY intermediate representation.
+//!
+//! This module defines the TACKY IR, a three-address code representation
+//! that sits between the C AST and the final x86_64 assembly.
 
 pub struct TackyProgram {
     pub function_definition: TackyFunctionDefinition,

--- a/src/tacky/builder.rs
+++ b/src/tacky/builder.rs
@@ -1,0 +1,143 @@
+//! TackyBuilder: A thin builder for emitting TACKY instructions.
+//!
+//! This builder encapsulates:
+//! - Name generation for temporaries and labels (replacing the global `static COUNTER`)
+//! - The instruction buffer with ergonomic `emit_*` methods
+//!
+//! # Design Principles
+//!
+//! - **Thin**: Does not reorder or optimize; emits exactly what you ask for
+//! - **Explicit**: Control flow patterns remain visible in the calling code
+//! - **Scoped naming**: Each builder instance has its own counter, making names
+//!   predictable within a function
+//!
+//! # Example
+//!
+//! ```ignore
+//! let mut builder = TackyBuilder::new();
+//!
+//! let tmp = builder.fresh_temp("x");
+//! builder.emit_copy(TackyValue::Constant(42), tmp.clone());
+//! builder.emit_return(tmp);
+//!
+//! let instructions = builder.finish();
+//! ```
+
+use crate::tacky::ast::{TackyIdentifier, TackyInstruction, TackyValue};
+
+/// Builder for constructing TACKY instruction sequences.
+///
+/// Manages name generation and instruction accumulation for lowering C AST to TACKY.
+pub struct TackyBuilder {
+    /// Accumulated instructions
+    instructions: Vec<TackyInstruction>,
+    /// Counter for generating unique names (temporaries and labels)
+    counter: usize,
+}
+
+impl TackyBuilder {
+    /// Creates a new builder with an empty instruction buffer.
+    pub fn new() -> Self {
+        TackyBuilder {
+            instructions: Vec::new(),
+            counter: 0,
+        }
+    }
+
+    /// Generates a fresh temporary variable with a unique suffix.
+    ///
+    /// Example: `fresh_temp("tmp")` → `TackyValue::Var("tmp.0")`, then `"tmp.1"`, etc.
+    pub fn fresh_temp(&mut self, name: &str) -> TackyValue {
+        let id = self.counter;
+        self.counter += 1;
+        TackyValue::Var(TackyIdentifier {
+            value: format!("{name}.{id}"),
+        })
+    }
+
+    /// Generates a fresh label identifier with a unique suffix.
+    ///
+    /// Example: `fresh_label("end")` → `TackyIdentifier { value: "end.0" }`
+    pub fn fresh_label(&mut self, name: &str) -> TackyIdentifier {
+        let id = self.counter;
+        self.counter += 1;
+        TackyIdentifier {
+            value: format!("{name}.{id}"),
+        }
+    }
+
+    /// Creates a label identifier with a prefix and the loop's label value.
+    /// Does NOT increment the counter (labels come from semantic analysis).
+    ///
+    /// Example: `label_with_prefix("break_", loop_label)` → `"break_loop.1"`
+    pub fn label_with_prefix(&self, prefix: &str, label: &crate::c_ast::ast::Identifier) -> TackyIdentifier {
+        TackyIdentifier {
+            value: format!("{}{}", prefix, label.value()),
+        }
+    }
+
+    // ========================================================================
+    // Basic emit methods
+    // ========================================================================
+
+    /// Emits a single instruction.
+    pub fn emit(&mut self, instruction: TackyInstruction) {
+        self.instructions.push(instruction);
+    }
+
+    /// Emits multiple instructions.
+    pub fn emit_all(&mut self, instructions: Vec<TackyInstruction>) {
+        self.instructions.extend(instructions);
+    }
+
+    /// Emits a Label instruction.
+    pub fn emit_label(&mut self, label: TackyIdentifier) {
+        self.emit(TackyInstruction::Label(label));
+    }
+
+    /// Emits a Jump instruction.
+    pub fn emit_jump(&mut self, target: TackyIdentifier) {
+        self.emit(TackyInstruction::Jump(target));
+    }
+
+    /// Emits a JumpIfZero instruction.
+    pub fn emit_jump_if_zero(&mut self, condition: TackyValue, target: TackyIdentifier) {
+        self.emit(TackyInstruction::JumpIfZero(condition, target));
+    }
+
+    /// Emits a JumpIfNotZero instruction.
+    pub fn emit_jump_if_not_zero(&mut self, condition: TackyValue, target: TackyIdentifier) {
+        self.emit(TackyInstruction::JumpIfNotZero(condition, target));
+    }
+
+    /// Emits a Copy instruction.
+    pub fn emit_copy(&mut self, src: TackyValue, dst: TackyValue) {
+        self.emit(TackyInstruction::Copy(src, dst));
+    }
+
+    /// Emits a Return instruction.
+    pub fn emit_return(&mut self, value: TackyValue) {
+        self.emit(TackyInstruction::Return(value));
+    }
+
+    // ========================================================================
+    // Finalization
+    // ========================================================================
+
+    /// Consumes the builder and returns the accumulated instructions.
+    pub fn finish(self) -> Vec<TackyInstruction> {
+        self.instructions
+    }
+
+    /// Returns the current number of instructions (useful for debugging).
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        self.instructions.len()
+    }
+}
+
+impl Default for TackyBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/tacky/builder.rs
+++ b/src/tacky/builder.rs
@@ -48,11 +48,7 @@ impl TackyBuilder {
     ///
     /// Example: `fresh_temp("tmp")` → `TackyValue::Var("tmp.0")`, then `"tmp.1"`, etc.
     pub fn fresh_temp(&mut self, name: &str) -> TackyValue {
-        let id = self.counter;
-        self.counter += 1;
-        TackyValue::Var(TackyIdentifier {
-            value: format!("{name}.{id}"),
-        })
+        TackyValue::Var(self.fresh_label(name))
     }
 
     /// Generates a fresh label identifier with a unique suffix.

--- a/src/tacky/builder.rs
+++ b/src/tacky/builder.rs
@@ -76,10 +76,6 @@ impl TackyBuilder {
         }
     }
 
-    // ========================================================================
-    // Basic emit methods
-    // ========================================================================
-
     /// Emits a single instruction.
     pub fn emit(&mut self, instruction: TackyInstruction) {
         self.instructions.push(instruction);
@@ -119,10 +115,6 @@ impl TackyBuilder {
     pub fn emit_return(&mut self, value: TackyValue) {
         self.emit(TackyInstruction::Return(value));
     }
-
-    // ========================================================================
-    // Finalization
-    // ========================================================================
 
     /// Consumes the builder and returns the accumulated instructions.
     pub fn finish(self) -> Vec<TackyInstruction> {

--- a/src/tacky/from.rs
+++ b/src/tacky/from.rs
@@ -1,4 +1,4 @@
-//! This module contains the logic to lower the AST to tacky IR
+//! This module contains the logic to lower the AST to TACKY IR.
 
 use log::{debug, info, trace};
 
@@ -7,9 +7,12 @@ use crate::{
         BinaryOperator, Block, BlockItem, Declaration, Expression, ForInit, FunctionDefinition,
         Identifier, Program, Statement, UnaryOperator,
     },
-    tacky::ast::{
-        TackyBinaryOperator, TackyFunctionDefinition, TackyIdentifier, TackyInstruction,
-        TackyProgram, TackyUnaryOperator, TackyValue,
+    tacky::{
+        ast::{
+            TackyBinaryOperator, TackyFunctionDefinition, TackyIdentifier, TackyInstruction,
+            TackyProgram, TackyUnaryOperator, TackyValue,
+        },
+        builder::TackyBuilder,
     },
 };
 
@@ -27,11 +30,13 @@ impl From<FunctionDefinition> for TackyFunctionDefinition {
     fn from(fd: FunctionDefinition) -> Self {
         trace!("[tacky] <function> {}", fd.name().value());
 
-        let mut instructions = TackyInstruction::from_block(fd.body().clone());
+        let mut builder = TackyBuilder::new();
+        emit_block(fd.body().clone(), &mut builder);
 
         // add return 0 as last instruction (it's gonna be fixed in Part III)
-        instructions.push(TackyInstruction::Return(TackyValue::Constant(0)));
+        builder.emit_return(TackyValue::Constant(0));
 
+        let instructions = builder.finish();
         info!("[tacky] {} instructions", instructions.len());
 
         TackyFunctionDefinition::new(TackyIdentifier::from(fd.name().clone()), instructions)
@@ -46,338 +51,301 @@ impl From<Identifier> for TackyIdentifier {
     }
 }
 
-impl TackyInstruction {
-    fn from_block(block: Block) -> Vec<TackyInstruction> {
-        block
-            .block_items()
-            .clone()
-            .into_iter()
-            .flat_map(TackyInstruction::from_block_item)
-            .collect()
-    }
+// ============================================================================
+// Lowering functions using TackyBuilder
+// ============================================================================
 
-    fn from_block_item(block_item: BlockItem) -> Vec<TackyInstruction> {
-        match block_item {
-            BlockItem::S(s) => TackyInstruction::from_st(s),
-            BlockItem::D(d) => TackyInstruction::from_decl(d),
+fn emit_block(block: Block, builder: &mut TackyBuilder) {
+    for item in block.block_items().clone() {
+        emit_block_item(item, builder);
+    }
+}
+
+fn emit_block_item(block_item: BlockItem, builder: &mut TackyBuilder) {
+    match block_item {
+        BlockItem::S(s) => emit_statement(s, builder),
+        BlockItem::D(d) => emit_declaration(d, builder),
+    }
+}
+
+fn emit_statement(statement: Statement, builder: &mut TackyBuilder) {
+    match statement {
+        Statement::Return(expr) => {
+            trace!("[tacky] <statement> return");
+            let v = emit_expr(expr, builder);
+            builder.emit_return(v);
+        }
+        Statement::Expression(expr) => {
+            trace!("[tacky] <statement> expression");
+            let _ = emit_expr(expr, builder);
+        }
+        Statement::If(cond, then, el) => {
+            trace!("[tacky] <statement> if");
+
+            let else_label = builder.fresh_label("else");
+            let end_label = builder.fresh_label("end");
+
+            // emit condition
+            let cond_result = emit_expr(*cond, builder);
+            let c = builder.fresh_temp("cond");
+            builder.emit_copy(cond_result, c.clone());
+            builder.emit_jump_if_zero(c, else_label.clone());
+
+            // emit then branch
+            emit_statement(*then, builder);
+            builder.emit_jump(end_label.clone());
+
+            // emit else branch
+            builder.emit_label(else_label);
+            if let Some(e) = el {
+                debug!("[tacky] else branch");
+                emit_statement(*e, builder);
+            }
+            builder.emit_label(end_label);
+        }
+        Statement::Compound(block) => {
+            trace!("[tacky] <statement> compound");
+            emit_block(*block, builder);
+        }
+        Statement::Break(label) => {
+            trace!("[tacky] <statement> break");
+            let break_label = builder.label_with_prefix("break_", &label);
+            builder.emit_jump(break_label);
+        }
+        Statement::Continue(label) => {
+            trace!("[tacky] <statement> continue");
+            let continue_label = builder.label_with_prefix("continue_", &label);
+            builder.emit_jump(continue_label);
+        }
+        Statement::While(cond, body, label) => {
+            trace!("[tacky] <statement> while");
+
+            let continue_label = builder.label_with_prefix("continue_", &label);
+            let break_label = builder.label_with_prefix("break_", &label);
+
+            builder.emit_label(continue_label.clone());
+
+            let res = emit_expr(*cond, builder);
+            let v = builder.fresh_temp("while_cond");
+            builder.emit_copy(res, v.clone());
+            builder.emit_jump_if_zero(v, break_label.clone());
+
+            emit_statement(*body, builder);
+            builder.emit_jump(continue_label);
+            builder.emit_label(break_label);
+        }
+        Statement::DoWhile(body, cond, label) => {
+            trace!("[tacky] <statement> do-while");
+
+            let start_label = builder.label_with_prefix("start_", &label);
+            let continue_label = builder.label_with_prefix("continue_", &label);
+            let break_label = builder.label_with_prefix("break_", &label);
+
+            builder.emit_label(start_label.clone());
+            emit_statement(*body, builder);
+            builder.emit_label(continue_label);
+
+            let res = emit_expr(*cond, builder);
+            let v = builder.fresh_temp("dowhile_cond");
+            builder.emit_copy(res, v.clone());
+            builder.emit_jump_if_not_zero(v, start_label);
+            builder.emit_label(break_label);
+        }
+        Statement::For(for_init, cond, post, body, label) => {
+            trace!("[tacky] <statement> for");
+
+            let start_label = builder.label_with_prefix("start_", &label);
+            let continue_label = builder.label_with_prefix("continue_", &label);
+            let break_label = builder.label_with_prefix("break_", &label);
+
+            // emit init
+            trace!("[tacky] for init");
+            emit_for_init(*for_init, builder);
+
+            builder.emit_label(start_label.clone());
+
+            // emit condition (if present)
+            if let Some(cond) = cond {
+                trace!("[tacky] for cond");
+                let res = emit_expr(*cond, builder);
+                let v = builder.fresh_temp("for_cond");
+                builder.emit_copy(res, v.clone());
+                builder.emit_jump_if_zero(v, break_label.clone());
+            }
+
+            // emit body
+            emit_statement(*body, builder);
+            builder.emit_label(continue_label);
+
+            // emit post (if present)
+            if let Some(post) = post {
+                trace!("[tacky] for post");
+                let _ = emit_expr(*post, builder);
+            }
+
+            builder.emit_jump(start_label);
+            builder.emit_label(break_label);
+        }
+        Statement::Null => {}
+    }
+}
+
+fn emit_declaration(declaration: Declaration, builder: &mut TackyBuilder) {
+    let Some(initializer) = declaration.initializer().cloned() else {
+        return;
+    };
+
+    let v = emit_expr(initializer, builder);
+    let dst = TackyValue::Var(TackyIdentifier::from(declaration.name().clone()));
+    builder.emit_copy(v, dst);
+}
+
+fn emit_for_init(for_init: ForInit, builder: &mut TackyBuilder) {
+    match for_init {
+        ForInit::InitDecl(declaration) => {
+            trace!("[tacky] for init with declaration");
+            emit_declaration(*declaration, builder);
+        }
+        ForInit::InitExp(expression) => {
+            let Some(expression) = expression else {
+                trace!("[tacky] for init with no expression");
+                return;
+            };
+            trace!("[tacky] for init with expression");
+            let _ = emit_expr(*expression, builder);
         }
     }
+}
 
-    fn from_st(statement: Statement) -> Vec<TackyInstruction> {
-        let mut instructions = vec![];
+/// Lowers an Expression to TACKY.
+/// Emits instructions via builder and returns a `TackyValue` identifying the result.
+fn emit_expr(expr: Expression, builder: &mut TackyBuilder) -> TackyValue {
+    match expr {
+        Expression::Conditional(cond, then, el) => {
+            trace!("[tacky] <exp> conditional");
 
-        match statement {
-            Statement::Return(expr) => {
-                trace!("[tacky] <statement> return");
+            let result = builder.fresh_temp("ternary_result");
+            let else_label = builder.fresh_label("ternary_else");
+            let end_label = builder.fresh_label("ternary_end");
 
-                let v = TackyInstruction::from_expr(expr, &mut instructions);
-                instructions.push(TackyInstruction::Return(v));
+            // emit condition
+            let cond_val = emit_expr(*cond, builder);
+            let c_result = builder.fresh_temp("ternary_cond");
+            builder.emit_copy(cond_val, c_result.clone());
+            builder.emit_jump_if_zero(c_result, else_label.clone());
 
-                instructions
-            }
-            Statement::Expression(expr) => {
-                trace!("[tacky] <statement> expression");
+            // emit then expression
+            let e1 = emit_expr(*then, builder);
+            builder.emit_copy(e1, result.clone());
+            builder.emit_jump(end_label.clone());
 
-                let _ = TackyInstruction::from_expr(expr, &mut instructions);
+            // emit else expression
+            builder.emit_label(else_label);
+            let e2 = emit_expr(*el, builder);
+            builder.emit_copy(e2, result.clone());
+            builder.emit_label(end_label);
 
-                instructions
-            }
-            Statement::If(cond, then, el) => {
-                trace!("[tacky] <statement> if");
+            result
+        }
+        Expression::Assignment(left, right) => {
+            trace!("[tacky] <exp> assignment");
 
-                let else_label = TackyIdentifier::new("else_label");
-                let end_label = TackyIdentifier::new("end");
+            let res = emit_expr(*right, builder);
+            let left_var = match *left {
+                Expression::Var(id) => TackyValue::Var(TackyIdentifier::from(id)),
+                _ => panic!("invalid lvalue in assignment"),
+            };
+            builder.emit_copy(res, left_var.clone());
 
-                // instructions for condition
-                let cond_result = TackyInstruction::from_expr(*cond, &mut instructions);
-                let c = TackyValue::Var(TackyIdentifier::new("c"));
-                instructions.push(TackyInstruction::Copy(cond_result, c.clone()));
-                instructions.push(TackyInstruction::JumpIfZero(c, else_label.clone()));
+            left_var
+        }
+        Expression::Var(id) => TackyValue::Var(TackyIdentifier::from(id)),
+        Expression::Constant(c) => TackyValue::Constant(c),
+        Expression::Unary(op, inner) => {
+            trace!("[tacky] <exp> unary {op:?}");
 
-                // instructions for then branch
-                instructions.extend(TackyInstruction::from_st(*then));
-                instructions.push(TackyInstruction::Jump(end_label.clone()));
+            let src = emit_expr(*inner, builder);
+            let dst = builder.fresh_temp("unary");
+            builder.emit(TackyInstruction::Unary(
+                TackyUnaryOperator::from(op),
+                src,
+                dst.clone(),
+            ));
 
-                instructions.push(TackyInstruction::Label(else_label));
-                if let Some(e) = el {
-                    debug!("[tacky] else branch");
-
-                    // instructions for else branch
-                    instructions.extend(TackyInstruction::from_st(*e));
-                }
-                instructions.push(TackyInstruction::Label(end_label));
-
-                instructions
-            }
-            Statement::Compound(block) => {
-                trace!("[tacky] <statement> compound");
-
-                instructions.extend(TackyInstruction::from_block(*block));
-
-                instructions
-            }
-            Statement::Break(label) => {
-                trace!("[tacky] <statement> break");
-
-                let break_label = TackyIdentifier::with_prefix("break_", label);
-                instructions.push(TackyInstruction::Jump(break_label));
-
-                instructions
-            }
-
-            Statement::Continue(label) => {
-                trace!("[tacky] <statement> continue");
-
-                let continue_label = TackyIdentifier::with_prefix("continue_", label);
-
-                instructions.push(TackyInstruction::Jump(continue_label));
-                instructions
-            }
-            Statement::While(cond, body, label) => {
-                trace!("[tacky] <statement> while");
-
-                let continue_label = TackyIdentifier::with_prefix("continue_", label.clone());
-                let break_label = TackyIdentifier::with_prefix("break_", label.clone());
-                let v = TackyIdentifier::new("v");
-
-                instructions.push(TackyInstruction::Label(continue_label.clone()));
-
-                let res = TackyInstruction::from_expr(*cond, &mut instructions);
-
-                instructions.push(TackyInstruction::Copy(res, TackyValue::Var(v.clone())));
-                instructions.push(TackyInstruction::JumpIfZero(
-                    TackyValue::Var(v),
-                    break_label.clone(),
-                ));
-                instructions.extend(TackyInstruction::from_st(*body));
-                instructions.push(TackyInstruction::Jump(continue_label));
-                instructions.push(TackyInstruction::Label(break_label));
-                instructions
-            }
-            Statement::DoWhile(body, cond, label) => {
-                trace!("[tacky] <statement> do-while");
-
-                let start_label = TackyIdentifier::with_prefix("start_", label.clone());
-                let continue_label = TackyIdentifier::with_prefix("continue_", label.clone());
-                let break_label = TackyIdentifier::with_prefix("break_", label);
-                let v = TackyIdentifier::new("v");
-
-                instructions.push(TackyInstruction::Label(start_label.clone()));
-                instructions.extend(TackyInstruction::from_st(*body));
-                instructions.push(TackyInstruction::Label(continue_label));
-
-                let res = TackyInstruction::from_expr(*cond, &mut instructions);
-
-                instructions.push(TackyInstruction::Copy(res, TackyValue::Var(v.clone())));
-                instructions.push(TackyInstruction::JumpIfNotZero(
-                    TackyValue::Var(v),
-                    start_label,
-                ));
-                instructions.push(TackyInstruction::Label(break_label));
-                instructions
-            }
-            Statement::For(for_init, cond, post, body, label) => {
-                trace!("[tacky] <statement> for");
-
-                let start_label = TackyIdentifier::with_prefix("start_", label.clone());
-                let continue_label = TackyIdentifier::with_prefix("continue_", label.clone());
-                let break_label = TackyIdentifier::with_prefix("break_", label);
-                let v = TackyIdentifier::new("v");
-
-                trace!("[tacky] for init");
-
-                TackyInstruction::from_for_init(for_init, &mut instructions);
-
-                instructions.push(TackyInstruction::Label(start_label.clone()));
-
-                if let Some(cond) = cond {
-                    trace!("[tacky] for cond");
-
-                    let res = TackyInstruction::from_expr(*cond, &mut instructions);
-
-                    instructions.push(TackyInstruction::Copy(res, TackyValue::Var(v.clone())));
-                    instructions.push(TackyInstruction::JumpIfZero(
-                        TackyValue::Var(v.clone()),
-                        break_label.clone(),
-                    ));
-                }
-
-                instructions.extend(TackyInstruction::from_st(*body));
-                instructions.push(TackyInstruction::Label(continue_label.clone()));
-
-                if let Some(post) = post {
-                    trace!("[tacky] for post");
-
-                    let _ = TackyInstruction::from_expr(*post, &mut instructions);
-                }
-
-                instructions.push(TackyInstruction::Jump(start_label));
-                instructions.push(TackyInstruction::Label(break_label));
-                instructions
-            }
-            Statement::Null => vec![],
+            dst
+        }
+        Expression::Binary(op, left, right) => {
+            trace!("[tacky] <exp> binary {op:?}");
+            emit_binary_op(op, *left, *right, builder)
         }
     }
+}
 
-    fn from_decl(declaration: Declaration) -> Vec<TackyInstruction> {
-        let mut instructions = vec![];
+fn emit_binary_op(
+    op: BinaryOperator,
+    left: Expression,
+    right: Expression,
+    builder: &mut TackyBuilder,
+) -> TackyValue {
+    match op {
+        // Short-circuit AND
+        BinaryOperator::And => {
+            let result = builder.fresh_temp("and_result");
+            let false_label = builder.fresh_label("and_false");
+            let end_label = builder.fresh_label("and_end");
 
-        let Some(initializer) = declaration.initializer().cloned() else {
-            return instructions;
-        };
+            let v1 = emit_expr(left, builder);
+            builder.emit_jump_if_zero(v1, false_label.clone());
 
-        let v = TackyInstruction::from_expr(initializer, &mut instructions);
-        instructions.push(TackyInstruction::Copy(
-            v,
-            TackyValue::Var(TackyIdentifier::from(declaration.name().clone())),
-        ));
+            let v2 = emit_expr(right, builder);
+            builder.emit_jump_if_zero(v2, false_label.clone());
 
-        instructions
-    }
+            builder.emit_copy(TackyValue::Constant(1), result.clone());
+            builder.emit_jump(end_label.clone());
 
-    /// Lowers an Expression to TACKY.
-    /// Appends the emitted instructions to `instructions` and returns
-    /// a `TackyValue` that identifies where the expression's result
-    /// now lives (a constant or a temporary/pseudo variable).
-    fn from_expr(expr: Expression, instructions: &mut Vec<TackyInstruction>) -> TackyValue {
-        match expr {
-            Expression::Conditional(cond, then, el) => {
-                trace!("[tacky] <exp> conditional");
+            builder.emit_label(false_label);
+            builder.emit_copy(TackyValue::Constant(0), result.clone());
 
-                let result = TackyValue::Var(TackyIdentifier::new("result"));
-                let c_result = TackyValue::Var(TackyIdentifier::new("c_result"));
-                let e2_label = TackyIdentifier::new("e2_label");
-                let end_label = TackyIdentifier::new("end");
+            builder.emit_label(end_label);
 
-                // instructions for condition
-                let cond_val = TackyInstruction::from_expr(*cond, instructions);
-                instructions.push(TackyInstruction::Copy(cond_val, c_result.clone()));
-                instructions.push(TackyInstruction::JumpIfZero(c_result, e2_label.clone()));
-
-                // instructions to calculate e1
-                let e1 = TackyInstruction::from_expr(*then, instructions);
-                let v1 = TackyValue::Var(TackyIdentifier::new("v1"));
-                instructions.push(TackyInstruction::Copy(e1, v1.clone()));
-                instructions.push(TackyInstruction::Copy(v1, result.clone()));
-                instructions.push(TackyInstruction::Jump(end_label.clone()));
-
-                // instructions to calculate e2
-                instructions.push(TackyInstruction::Label(e2_label));
-                let e2 = TackyInstruction::from_expr(*el, instructions);
-                let v2 = TackyValue::Var(TackyIdentifier::new("v2"));
-                instructions.push(TackyInstruction::Copy(e2, v2.clone()));
-                instructions.push(TackyInstruction::Copy(v2, result.clone()));
-                instructions.push(TackyInstruction::Label(end_label));
-
-                result
-            }
-            Expression::Assignment(left, right) => {
-                trace!("[tacky] <exp> assignment");
-
-                let res = TackyInstruction::from_expr(*right, instructions);
-                let left_var = match *left {
-                    Expression::Var(id) => TackyValue::Var(TackyIdentifier::from(id)),
-                    _ => panic!("invalid lvalue in assignment"),
-                };
-                instructions.push(TackyInstruction::Copy(res, left_var.clone()));
-
-                left_var
-            }
-            Expression::Var(id) => TackyValue::Var(TackyIdentifier::from(id)),
-            Expression::Constant(c) => TackyValue::Constant(c),
-            Expression::Unary(op, inner) => {
-                trace!("[tacky] <exp> unary {op:?}");
-
-                let src = TackyInstruction::from_expr(*inner, instructions);
-                // TODO: provide a more descriptive name
-                let dst = TackyValue::Var(TackyIdentifier::new("unary_op"));
-                instructions.push(TackyInstruction::Unary(
-                    TackyUnaryOperator::from(op),
-                    src,
-                    dst.clone(),
-                ));
-
-                dst
-            }
-            Expression::Binary(op, left, right) => {
-                trace!("[tacky] <exp> binary {op:?}");
-
-                TackyInstruction::from_bin_op(instructions, op, left, right)
-            }
+            result
         }
-    }
+        // Short-circuit OR
+        BinaryOperator::Or => {
+            let result = builder.fresh_temp("or_result");
+            let true_label = builder.fresh_label("or_true");
+            let end_label = builder.fresh_label("or_end");
 
-    fn from_bin_op(
-        instructions: &mut Vec<TackyInstruction>,
-        op: BinaryOperator,
-        left: Box<Expression>,
-        right: Box<Expression>,
-    ) -> TackyValue {
-        match op {
-            BinaryOperator::And => {
-                let result = TackyValue::Var(TackyIdentifier::new("and_result"));
-                let false_label = TackyIdentifier::new("false_label");
-                let end_label = TackyIdentifier::new("end");
+            let v1 = emit_expr(left, builder);
+            builder.emit_jump_if_not_zero(v1, true_label.clone());
 
-                let v1 = TackyInstruction::from_expr(*left, instructions);
-                instructions.push(TackyInstruction::JumpIfZero(v1, false_label.clone()));
+            let v2 = emit_expr(right, builder);
+            builder.emit_jump_if_not_zero(v2, true_label.clone());
 
-                let v2 = TackyInstruction::from_expr(*right, instructions);
-                instructions.push(TackyInstruction::JumpIfZero(v2, false_label.clone()));
+            builder.emit_copy(TackyValue::Constant(0), result.clone());
+            builder.emit_jump(end_label.clone());
 
-                instructions.push(TackyInstruction::Copy(
-                    TackyValue::Constant(1),
-                    result.clone(),
-                ));
-                instructions.push(TackyInstruction::Jump(end_label.clone()));
-                instructions.push(TackyInstruction::Label(false_label));
-                instructions.push(TackyInstruction::Copy(
-                    TackyValue::Constant(0),
-                    result.clone(),
-                ));
-                instructions.push(TackyInstruction::Label(end_label));
+            builder.emit_label(true_label);
+            builder.emit_copy(TackyValue::Constant(1), result.clone());
 
-                result
-            }
-            BinaryOperator::Or => {
-                let result = TackyValue::Var(TackyIdentifier::new("or_result"));
-                let true_label = TackyIdentifier::new("true_label");
-                let end_label = TackyIdentifier::new("end");
+            builder.emit_label(end_label);
 
-                let v1 = TackyInstruction::from_expr(*left, instructions);
-                instructions.push(TackyInstruction::JumpIfNotZero(v1, true_label.clone()));
+            result
+        }
+        // Regular binary operators
+        _ => {
+            let v1 = emit_expr(left, builder);
+            let v2 = emit_expr(right, builder);
+            let dst = builder.fresh_temp("binop");
 
-                let v2 = TackyInstruction::from_expr(*right, instructions);
-                instructions.push(TackyInstruction::JumpIfNotZero(v2, true_label.clone()));
+            builder.emit(TackyInstruction::Binary(
+                TackyBinaryOperator::from(op),
+                v1,
+                v2,
+                dst.clone(),
+            ));
 
-                instructions.push(TackyInstruction::Copy(
-                    TackyValue::Constant(0),
-                    result.clone(),
-                ));
-                instructions.push(TackyInstruction::Jump(end_label.clone()));
-                instructions.push(TackyInstruction::Label(true_label));
-                instructions.push(TackyInstruction::Copy(
-                    TackyValue::Constant(1),
-                    result.clone(),
-                ));
-                instructions.push(TackyInstruction::Label(end_label));
-
-                result
-            }
-            _ => {
-                let v1 = TackyInstruction::from_expr(*left, instructions);
-                let v2 = TackyInstruction::from_expr(*right, instructions);
-                let dst = TackyValue::Var(TackyIdentifier::new("binary_op"));
-
-                instructions.push(TackyInstruction::Binary(
-                    TackyBinaryOperator::from(op),
-                    v1,
-                    v2,
-                    dst.clone(),
-                ));
-
-                dst
-            }
+            dst
         }
     }
 }
@@ -419,21 +387,3 @@ impl From<BinaryOperator> for TackyBinaryOperator {
     }
 }
 
-impl TackyInstruction {
-    pub fn from_for_init(for_init: Box<ForInit>, instructions: &mut Vec<TackyInstruction>) {
-        match *for_init {
-            ForInit::InitDecl(declaration) => {
-                trace!("[tacky] for init with declaration");
-                instructions.extend(TackyInstruction::from_decl(*declaration));
-            }
-            ForInit::InitExp(expression) => {
-                let Some(expression) = expression else {
-                    trace!("[tacky] for init with no expression");
-                    return;
-                };
-                trace!("[tacky] for init with expression");
-                let _ = TackyInstruction::from_expr(*expression, instructions);
-            }
-        };
-    }
-}

--- a/src/tacky/from.rs
+++ b/src/tacky/from.rs
@@ -53,10 +53,6 @@ impl From<Identifier> for TackyIdentifier {
     }
 }
 
-// ============================================================================
-// Lowering functions using TackyBuilder
-// ============================================================================
-
 fn emit_block(block: Block, builder: &mut TackyBuilder) {
     for item in block.into_block_items() {
         emit_block_item(item, builder);
@@ -292,7 +288,7 @@ fn emit_binary_op(
     builder: &mut TackyBuilder,
 ) -> TackyValue {
     match op {
-        // Short-circuit AND
+        // short-circuit AND
         BinaryOperator::And => {
             let result = builder.fresh_temp("and_result");
             let false_label = builder.fresh_label("and_false");
@@ -314,7 +310,7 @@ fn emit_binary_op(
 
             result
         }
-        // Short-circuit OR
+        // short-circuit OR
         BinaryOperator::Or => {
             let result = builder.fresh_temp("or_result");
             let true_label = builder.fresh_label("or_true");
@@ -336,7 +332,7 @@ fn emit_binary_op(
 
             result
         }
-        // Regular binary operators
+        // regular binary operators
         _ => {
             let v1 = emit_expr(left, builder);
             let v2 = emit_expr(right, builder);

--- a/src/tacky/mod.rs
+++ b/src/tacky/mod.rs
@@ -1,3 +1,4 @@
 pub mod ast;
+pub mod builder;
 pub mod display;
 pub mod from;

--- a/test/folder_tests.rs
+++ b/test/folder_tests.rs
@@ -1,5 +1,5 @@
 use fcc::codegen::x64::ast::{
-    AsmBinaryOperator, AsmCondCode, AsmFunctionDefinition, AsmIdetifier, AsmInstruction,
+    AsmBinaryOperator, AsmCondCode, AsmFunctionDefinition, AsmIdentifier, AsmInstruction,
     AsmOperand, AsmProgram, AsmUnaryOperator, Reg,
 };
 use fcc::codegen::x64::fixer::instruction_fix::InstructionFixer;
@@ -20,7 +20,7 @@ fn test_basic_folder_trait() {
     }
 
     let folder = BasicFolder::create();
-    let identifier = AsmIdetifier {
+    let identifier = AsmIdentifier {
         value: "test".to_string(),
     };
     let instructions = vec![AsmInstruction::Ret];
@@ -65,17 +65,17 @@ fn test_folder_preserves_all_instruction_types() {
         AsmInstruction::Cmp(AsmOperand::Register(Reg::AX), AsmOperand::Imm(0)),
         AsmInstruction::Idiv(AsmOperand::Register(Reg::DX)),
         AsmInstruction::Cdq,
-        AsmInstruction::Jmp(AsmIdetifier {
+        AsmInstruction::Jmp(AsmIdentifier {
             value: "label1".to_string(),
         }),
         AsmInstruction::JmpCC(
             AsmCondCode::E,
-            AsmIdetifier {
+            AsmIdentifier {
                 value: "label2".to_string(),
             },
         ),
         AsmInstruction::SetCC(AsmCondCode::NE, AsmOperand::Register(Reg::CL)),
-        AsmInstruction::Label(AsmIdetifier {
+        AsmInstruction::Label(AsmIdentifier {
             value: "label1".to_string(),
         }),
         AsmInstruction::AllocateStack(16),
@@ -85,7 +85,7 @@ fn test_folder_preserves_all_instruction_types() {
     let instructions_clone = instructions.clone();
 
     let function = AsmFunctionDefinition::new(
-        AsmIdetifier {
+        AsmIdentifier {
             value: "main".to_string(),
         },
         instructions,
@@ -163,7 +163,7 @@ fn test_folder_with_all_operand_types() {
         AsmOperand::Register(Reg::CL),
         AsmOperand::Register(Reg::R10),
         AsmOperand::Register(Reg::R11),
-        AsmOperand::Pseudo(AsmIdetifier {
+        AsmOperand::Pseudo(AsmIdentifier {
             value: "var1".to_string(),
         }),
         AsmOperand::Stack(-4),
@@ -305,7 +305,7 @@ fn test_instruction_fixer_basic_functionality() {
     ];
 
     let function = AsmFunctionDefinition::new(
-        AsmIdetifier {
+        AsmIdentifier {
             value: "main".to_string(),
         },
         instructions,
@@ -323,7 +323,7 @@ fn test_instruction_fixer_basic_functionality() {
 
         match &fixed_function.instructions[1] {
             AsmInstruction::Comment(comment) => {
-                assert!(comment.contains("splited mov"));
+                assert!(comment.contains("fix: mov mem,mem"));
             }
             _ => panic!("Expected Comment instruction"),
         }
@@ -335,7 +335,7 @@ fn test_instruction_fixer_idiv_immediate() {
     let instructions = vec![AsmInstruction::Idiv(AsmOperand::Imm(42))];
 
     let function = AsmFunctionDefinition::new(
-        AsmIdetifier {
+        AsmIdentifier {
             value: "main".to_string(),
         },
         instructions,
@@ -348,7 +348,7 @@ fn test_instruction_fixer_idiv_immediate() {
 
         match &fixed_function.instructions[1] {
             AsmInstruction::Comment(comment) => {
-                assert!(comment.contains("splited idiv"));
+                assert!(comment.contains("fix: idiv imm"));
             }
             _ => panic!("Expected Comment instruction"),
         }
@@ -370,12 +370,12 @@ fn test_pseudo_register_replacer_basic_functionality() {
     let instructions = vec![
         AsmInstruction::Mov(
             AsmOperand::Imm(42),
-            AsmOperand::Pseudo(AsmIdetifier {
+            AsmOperand::Pseudo(AsmIdentifier {
                 value: "var1".to_string(),
             }),
         ),
         AsmInstruction::Mov(
-            AsmOperand::Pseudo(AsmIdetifier {
+            AsmOperand::Pseudo(AsmIdentifier {
                 value: "var1".to_string(),
             }),
             AsmOperand::Register(Reg::AX),
@@ -384,7 +384,7 @@ fn test_pseudo_register_replacer_basic_functionality() {
     ];
 
     let function = AsmFunctionDefinition::new(
-        AsmIdetifier {
+        AsmIdentifier {
             value: "main".to_string(),
         },
         instructions,
@@ -411,22 +411,22 @@ fn test_pseudo_register_replacer_multiple_variables() {
     let instructions = vec![
         AsmInstruction::Mov(
             AsmOperand::Imm(1),
-            AsmOperand::Pseudo(AsmIdetifier {
+            AsmOperand::Pseudo(AsmIdentifier {
                 value: "var1".to_string(),
             }),
         ),
         AsmInstruction::Mov(
             AsmOperand::Imm(2),
-            AsmOperand::Pseudo(AsmIdetifier {
+            AsmOperand::Pseudo(AsmIdentifier {
                 value: "var2".to_string(),
             }),
         ),
         AsmInstruction::Binary(
             AsmBinaryOperator::Add,
-            AsmOperand::Pseudo(AsmIdetifier {
+            AsmOperand::Pseudo(AsmIdentifier {
                 value: "var1".to_string(),
             }),
-            AsmOperand::Pseudo(AsmIdetifier {
+            AsmOperand::Pseudo(AsmIdentifier {
                 value: "var2".to_string(),
             }),
         ),
@@ -434,7 +434,7 @@ fn test_pseudo_register_replacer_multiple_variables() {
     ];
 
     let function = AsmFunctionDefinition::new(
-        AsmIdetifier {
+        AsmIdentifier {
             value: "main".to_string(),
         },
         instructions,
@@ -479,7 +479,7 @@ fn test_folder_preserves_identifiers() {
     }
 
     let mut folder = IdentityFolder::create();
-    let original_id = AsmIdetifier {
+    let original_id = AsmIdentifier {
         value: "test_identifier_123".to_string(),
     };
 

--- a/test/tacky_tests.rs
+++ b/test/tacky_tests.rs
@@ -5,15 +5,18 @@ use fcc::tacky::ast::{
 
 #[test]
 fn test_tacky_identifier_creation() {
+    // TackyIdentifier::new is now a simple constructor (no counter)
+    // For unique names, use TackyBuilder::fresh_temp/fresh_label
     let id1 = TackyIdentifier::new("test");
     let id2 = TackyIdentifier::new("test");
 
-    assert!(id1.value.starts_with("test."));
-    assert!(id2.value.starts_with("test."));
-    assert_ne!(id1.value, id2.value);
+    assert_eq!(id1.value, "test");
+    assert_eq!(id2.value, "test");
+    // Same name is fine for direct construction
+    assert_eq!(id1.value, id2.value);
 
     let id3 = TackyIdentifier::new("main");
-    assert!(id3.value.starts_with("main."));
+    assert_eq!(id3.value, "main");
 }
 
 #[test]
@@ -46,7 +49,7 @@ fn test_tacky_program_creation() {
     let function_def = TackyFunctionDefinition::new(name, instructions);
     let program = TackyProgram::new(function_def);
 
-    assert!(program.function_definition.name.value.starts_with("main."));
+    assert_eq!(program.function_definition.name.value, "main");
     assert_eq!(program.function_definition.instructions.len(), 1);
 
     if let TackyInstruction::Return(TackyValue::Constant(val)) =
@@ -64,7 +67,7 @@ fn test_tacky_function_definition_creation() {
     let instructions = vec![TackyInstruction::Return(TackyValue::Constant(42))];
     let func_def = TackyFunctionDefinition::new(name, instructions);
 
-    assert!(func_def.name.value.starts_with("func."));
+    assert_eq!(func_def.name.value, "func");
     assert_eq!(func_def.instructions.len(), 1);
 }
 
@@ -165,7 +168,7 @@ fn test_tacky_instruction_jump() {
     let jump_inst = TackyInstruction::Jump(label);
 
     if let TackyInstruction::Jump(lbl) = jump_inst {
-        assert!(lbl.value.starts_with("label1."));
+        assert_eq!(lbl.value, "label1");
     } else {
         panic!("Expected jump instruction");
     }
@@ -183,8 +186,7 @@ fn test_tacky_instruction_jump_if_zero() {
         } else {
             panic!("Expected variable value");
         }
-        println!("{}", lbl.value);
-        assert!(lbl.value.starts_with("zero_label."));
+        assert_eq!(lbl.value, "zero_label");
     } else {
         panic!("Expected jump if zero instruction");
     }
@@ -202,7 +204,7 @@ fn test_tacky_instruction_jump_if_not_zero() {
         } else {
             panic!("Expected constant value");
         }
-        assert!(lbl.value.starts_with("nonzero_label."));
+        assert_eq!(lbl.value, "nonzero_label");
     } else {
         panic!("Expected jump if not zero instruction");
     }
@@ -214,7 +216,7 @@ fn test_tacky_instruction_label() {
     let label_inst = TackyInstruction::Label(label);
 
     if let TackyInstruction::Label(lbl) = label_inst {
-        assert!(lbl.value.starts_with("my_label."));
+        assert_eq!(lbl.value, "my_label");
     } else {
         panic!("Expected label instruction");
     }


### PR DESCRIPTION
In this PR:
- Add `TackyBuilder` to simplify TACKY IR construction 
- Add `into_*` methods to C-AST to eliminate unnecessary clones during lowering
- Extract helpers and document x86_64 codegen `reg_replace` and `fix-up` passes
